### PR TITLE
Added "Edit this page" link to docs

### DIFF
--- a/docusaurus.config.js
+++ b/docusaurus.config.js
@@ -146,6 +146,9 @@ const config = {
         docs: {
           routeBasePath: '/book/',
           sidebarPath: require.resolve('./sidebars.js'),
+          editUrl: ({ docPath }) => {
+            return `https://holocron.so/github/pr/Mihonarium/hpmor-ru/master/editor/docs/${docPath}`
+          },
         },
         theme: {
           customCss: require.resolve('./src/css/custom.css'),


### PR DESCRIPTION
With this PR readers can suggest changes to the docs with an easy to use WYSIWYG markdown editor.

[This](https://holocron.so/github/pr/Mihonarium/hpmor-ru/master/editor) is how the editor looks like for this repo.

https://github.com/remorses/docusaurus-example/assets/31321188/43c8bc68-3668-4a25-bf1c-a70eceab7bcb